### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,9 @@ It was used to pull over 1MM+ products and their images from amazon in a few hou
 After you get a copy of this codebase pulled down locally (either downloaded as a zip or git cloned), you'll need to install the python dependencies:
 
     pip install -r requirements.txt
+    
+    Installation on Mac OS X version 10.11.6:
+    sudo pip install -r requirements.txt --user
 
 Then you'll need to go into the `settings.py` file and update a number of values:
 


### PR DESCRIPTION
Installation on Mac OS X version 10.11.6 (maybe even earlier versions) requires additional options to be able to install the required packages. I realised this after I got the following error message:

error: could not create '/System/Library/Frameworks/Python.framework/Versions/2.7/include/python2.7/greenlet': Operation not permitted.
